### PR TITLE
Some fixes and improvements

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=NPCPoisonVenomTracker
 author=Subzotic
 support=https://github.com/Subzotic/NPCPoisonVenomTracker.git
-description=Tracks what NPCs have been inflicted by Poison/Venom.
-tags=npc, highlight, overlay, poison, venom
-plugins=com.NPCPoisonVenomTracker
+description=Tracks NPCs that have been inflicted by Poison or Venom
+tags=npc,highlight,overlay,poison,venom
+plugins=com.NPCPoisonVenomTracker.NPCPoisonVenomTrackerPlugin

--- a/src/main/java/com/NPCPoisonVenomTracker/InflictedNPC.java
+++ b/src/main/java/com/NPCPoisonVenomTracker/InflictedNPC.java
@@ -1,0 +1,17 @@
+package com.NPCPoisonVenomTracker;
+
+
+import net.runelite.api.NPC;
+
+public interface InflictedNPC
+{
+    NPC getNPC();
+    void processTick();
+    void processHitsplat(int damage);
+    int getNextDamage();
+    int getTicksUntilNextHit();
+    int getTicksRemaining();
+    int getHitsRemaining();
+    int getHitsplatType();
+    boolean hasExpired();
+}

--- a/src/main/java/com/NPCPoisonVenomTracker/NPCPoisonVenomTrackerConfig.java
+++ b/src/main/java/com/NPCPoisonVenomTracker/NPCPoisonVenomTrackerConfig.java
@@ -11,20 +11,46 @@ public interface NPCPoisonVenomTrackerConfig extends Config
 {
 	@ConfigItem(
 			position = 0,
-			keyName = "highlightColor",
-			name = "Highlight Color",
-			description = "The color to use for highlighting NPCs inflicted with Poison/Venom"
+			keyName = "poisonHighlightColor",
+			name = "Poison Highlight Color",
+			description = "The color to use for highlighting NPCs inflicted with Poison"
 	)
-	default String highlightColor()
+	default Color poisonHighlightColor()
 	{
-		return "#C8FF00";
+		return new Color(200, 255, 0); //aka #C8FF00
 	}
 
-	void setHighlightColor(String color);
-
-	default Color getHighlightColor()
+	@ConfigItem(
+			position = 1,
+			keyName = "venomHighlightColor",
+			name = "Venom Highlight Color",
+			description = "The color to use for highlighting NPCs inflicted with Venom"
+	)
+	default Color venomHighlightColor()
 	{
-		return Color.decode(highlightColor());
+		return new Color(0, 255, 111);
+	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "textColor",
+			name = "Text Color",
+			description = "The color to use for text above inflicted NPCs"
+	)
+	default Color textColor()
+	{
+		return new Color(255, 255, 255);
+	}
+
+	@ConfigItem(
+			position = 3,
+			keyName = "showTicksAsTime",
+			name = "Show as time remaining",
+			description = "Replaces ticks with time remaining"
+	)
+	default boolean showTicksAsTime()
+	{
+		return true;
 	}
 }
 

--- a/src/main/java/com/NPCPoisonVenomTracker/NPCPoisonVenomTrackerPlugin.java
+++ b/src/main/java/com/NPCPoisonVenomTracker/NPCPoisonVenomTrackerPlugin.java
@@ -1,23 +1,42 @@
 package com.NPCPoisonVenomTracker;
 
+import com.google.inject.Provides;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Actor;
+import net.runelite.api.HitsplatID;
+import net.runelite.api.NPC;
+import net.runelite.api.events.*;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.NPCManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
+@Slf4j
 @PluginDescriptor(
-		name = "NPC Poison/Venom Tracker",
+		name = "NPCPoisonVenomTracker",
 		description = "Tracks NPCs that have been inflicted by Poison or Venom",
 		tags = {"overlay", "highlight", "NPC", "poison", "venom"}
 )
 public class NPCPoisonVenomTrackerPlugin extends Plugin
 {
+	@Getter
+	private final Map<NPC, InflictedNPC> inflictedNPCs = new HashMap();
 	@Inject
 	private OverlayManager overlayManager;
-
 	@Inject
 	private NPCPoisonVenomTrackerOverlay overlay;
+	@Inject
+	private NPCManager npcManager;
+	@Getter
+	private long lastGameTick;
 
 	@Override
 	protected void startUp() throws Exception
@@ -30,4 +49,88 @@ public class NPCPoisonVenomTrackerPlugin extends Plugin
 	{
 		overlayManager.remove(overlay);
 	}
+
+	@Subscribe
+	public void onClientTick(ClientTick event)
+	{
+		inflictedNPCs.entrySet().removeIf(e -> e.getValue().hasExpired()); // Clear expired inflicted NPCs
+	}
+
+	@Subscribe
+	public void onGameTick(GameTick event)
+	{
+		inflictedNPCs.values().forEach(InflictedNPC::processTick); // Process game tick count for each inflicted NPC
+		lastGameTick = Instant.now().toEpochMilli(); // Used for time remaining in overlay
+	}
+
+	@Subscribe
+	public void onHitsplatApplied(HitsplatApplied event)
+	{
+		Actor actor = event.getActor();
+		if (!(actor instanceof NPC)) // Ignored non-NPC actors
+		{
+			return;
+		}
+
+		NPC npc = (NPC) actor;
+		if (npc.isDead()) // Ignore dead NPCs
+		{
+			return;
+		}
+
+		int damage = event.getHitsplat().getAmount();
+		int hitsplatType = event.getHitsplat().getHitsplatType();
+
+		if (hitsplatType != HitsplatID.POISON && hitsplatType != HitsplatID.VENOM) // Ignore irrelevant hitsplat types
+		{
+			return;
+		}
+
+		if (inflictedNPCs.containsKey(npc))
+		{
+			InflictedNPC existing = inflictedNPCs.get(npc);
+			if (existing.getHitsplatType() != hitsplatType)
+			{
+				inflictedNPCs.remove(npc); // Allows venom to override poison
+			}
+			else
+			{
+				existing.processHitsplat(damage);
+				return;
+			}
+		}
+
+		if (hitsplatType == HitsplatID.POISON)
+		{
+			inflictedNPCs.put(npc, new PoisonedNPC(npc, damage));
+		}
+		else // Venom
+		{
+			inflictedNPCs.put(npc, new VenomedNPC(npc));
+		}
+	}
+
+	@Subscribe
+	public void onNpcDespawned(NpcDespawned event)
+	{
+		inflictedNPCs.remove(event.getNpc()); // Remove de-spawned inflicted NPCs from map
+	}
+
+	@Subscribe
+	public void onActorDeath(ActorDeath event) // Remove dead inflicted NPCs from map
+	{
+		if (!(event.getActor() instanceof NPC))
+		{
+			return;
+		}
+
+		inflictedNPCs.remove(event.getActor());
+	}
+
+	@Provides
+	NPCPoisonVenomTrackerConfig provideConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(NPCPoisonVenomTrackerConfig.class);
+	}
+
 }

--- a/src/main/java/com/NPCPoisonVenomTracker/PoisonedNPC.java
+++ b/src/main/java/com/NPCPoisonVenomTracker/PoisonedNPC.java
@@ -1,0 +1,101 @@
+package com.NPCPoisonVenomTracker;
+
+import lombok.Getter;
+import net.runelite.api.HitsplatID;
+import net.runelite.api.NPC;
+
+@Getter
+public class PoisonedNPC implements InflictedNPC
+{
+    // Information sourced from: https://oldschool.runescape.wiki/w/Poison and https://oldschoolrunescape.fandom.com/wiki/Poison
+
+    // Starts at a random damage value dependent on source
+    // Poison applies every 18 seconds (30 ticks)
+    // Every 4* hits, the poison damage value decreases by 1 (* wiki says 5 hits, fandom says 4 hits)
+    // The poison timer is reset if poison is successfully applied again while poisoned (damage is also reset)
+    // 'Some NPCs with their own timers for actions like speaking can't be poisoned' (untested, no logic to handle this yet)
+
+    private final int TICKS_PER_HIT = 30;
+    private final int HITS_PER_DAMAGE_CHANGE = 5;
+    private final int TICKS_PER_HP_REGEN = 60;
+    private int lastDamage;
+    private int nextDamage;
+    private int hitsSinceDamageChange;
+    private int ticksUntilNextHit;
+    private final NPC NPC;
+
+    public PoisonedNPC(NPC npc, int damage)
+    {
+        this.NPC = npc;
+        this.lastDamage = damage;
+        this.ticksUntilNextHit = TICKS_PER_HIT + 1; // Start offset by 1 tick
+        this.hitsSinceDamageChange = 0;
+        updateNextDamage();
+    }
+
+    public void processTick() // We process ticks for the timer overlay
+    {
+        ticksUntilNextHit--;
+    }
+
+    public void processHitsplat(int damage) // Unlike with Venom, we need to process each hitsplat manually just in case poison has been re-applied (which would reset the internal timer and damage)
+    {
+        ticksUntilNextHit = TICKS_PER_HIT + 1; // Reset, offset by 1 tick
+
+        if (damage != nextDamage) // Damage mismatch - Poison has been re-applied, reset damage and hit counter
+        {
+            lastDamage = damage;
+            hitsSinceDamageChange = 0;
+        }
+        else // Normal poison damage tick
+        {
+            hitsSinceDamageChange++;
+        }
+
+        if (hitsSinceDamageChange == HITS_PER_DAMAGE_CHANGE)
+        {
+            lastDamage--;
+            hitsSinceDamageChange = 0;
+        }
+
+        updateNextDamage();
+    }
+
+    public int getTicksRemaining()
+    {
+        return ticksUntilNextHit + getHitsRemaining() * TICKS_PER_HIT;
+    }
+
+    public int getHitsRemaining()
+    {
+        return (HITS_PER_DAMAGE_CHANGE - hitsSinceDamageChange) + ((lastDamage - 1) * HITS_PER_DAMAGE_CHANGE);
+    }
+
+    public int getHitsplatType()
+    {
+        return HitsplatID.POISON;
+    }
+
+    @Override
+    public boolean hasExpired()
+    {
+        return nextDamage == -1;
+    }
+
+    private void updateNextDamage() // Updates the next hit's predicted damage value
+    {
+        if (hitsSinceDamageChange + 1 == HITS_PER_DAMAGE_CHANGE)
+        {
+            nextDamage = lastDamage - 1;
+        }
+        else if (lastDamage <= 0)
+        {
+            nextDamage = -1;
+        }
+        else
+        {
+            nextDamage = lastDamage;
+        }
+    }
+
+}

--- a/src/main/java/com/NPCPoisonVenomTracker/VenomedNPC.java
+++ b/src/main/java/com/NPCPoisonVenomTracker/VenomedNPC.java
@@ -1,0 +1,77 @@
+package com.NPCPoisonVenomTracker;
+
+import lombok.Getter;
+import net.runelite.api.HitsplatID;
+import net.runelite.api.NPC;
+
+@Getter
+public class VenomedNPC implements InflictedNPC
+{
+    // Information sourced from: https://oldschool.runescape.wiki/w/Venom
+
+    // Starts at damage value of 6
+    // Venom applies every 18 seconds (30 ticks)
+    // Every hit, the venom damage value increases by 2
+    // Damage caps at 20
+    // Unlike poison, the timer is not reset when applying venom again with another attack
+
+    private final int TICKS_PER_HIT = 30;
+    private final int INITIAL_DAMAGE = 6;
+    private final int DAMAGE_INCREASE_PER_HIT = 2;
+    private final int MAX_DAMAGE_PER_HIT = 20;
+    private int lastDamage;
+    private int nextDamage;
+    private int ticksUntilNextHit;
+    private final NPC NPC;
+
+    public VenomedNPC(NPC npc)
+    {
+        this.NPC = npc;
+        this.lastDamage = INITIAL_DAMAGE;
+        this.ticksUntilNextHit = TICKS_PER_HIT + 1;
+        updateNextDamage();
+    }
+
+    public void processTick()
+    {
+        ticksUntilNextHit--;
+    }
+
+    // We technically don't need the below method for Venom, we could process the damage increase in the above method only
+    // but if the client hangs for a few frames (or when debugging) it can sometimes de-sync the timer, this solves that issue by processing it manually instead.
+
+    public void processHitsplat(int damage)
+    {
+        lastDamage = damage;
+        ticksUntilNextHit = TICKS_PER_HIT + 1; // Offset by 1 tick because next hitsplat occurs 1 tick after damage calculation
+
+        updateNextDamage();
+    }
+
+    public int getTicksRemaining() // Infinite until cured
+    {
+        return -1;
+    }
+
+    public int getHitsRemaining() // Infinite until cured
+    {
+        return -1;
+    }
+
+    public int getHitsplatType()
+    {
+        return HitsplatID.VENOM;
+    }
+
+    @Override
+    public boolean hasExpired() // Venom can't expire with time, only when the target is dead or the venom is cured
+    {
+        return false;
+    }
+
+    private void updateNextDamage()
+    {
+        nextDamage = Math.min(lastDamage + DAMAGE_INCREASE_PER_HIT, MAX_DAMAGE_PER_HIT);
+    }
+
+}


### PR DESCRIPTION
The original code wasn't functioning because it had some incorrect method names for events (e.g. OnHitApplied) and the overlay class wasn't set up correctly to subscribe to events.

This PR fixes those issues and also implements a couple classes that represent the logic behind both poison and venom. These classes essentially process each tick and calculate how many ticks until the next hit, as well as how much damage that hit will be and so on. Additionally, the overlay has been altered to highlight the hull of inflicted NPCs, and currently also includes debug text above the inflicted NPC in the format of {Next_Damage | Ticks_Until_Hit | Ticks_Remaining}. I've added a basic config options as well, such as the highlight color for posion/venom inflicted NPCs, and the option to show remaining ticks as remaining seconds instead.

I sourced nearly all of the information for this from the wiki. I've done a small amount of testing and it seems to be accurate, but it likely needs to be tested further.

Some suggestions for other improvements to the plugin:
- Show which NPCs have been hit by a poisoned/venom weapon prior to infliction (this could include a timer that indicates when an NPC needs to be attacked again, in cases where the poison/venom application was unsuccessfull)
- Timer until the NPC is killed
- More overlay options (highlight tile, outline etc)
- Proper formatting and options for the debug text

Apologies if this is not what you had in mind when you created the discussion. I'm happy to remove parts if you just want the overlay without tracking the timers/damage etc, and if you want to use this PR as a reference instead of merging it, that's totally fine too. Let me know if you need any further help!
